### PR TITLE
issue-48-(receiver value bug when clicking 'message' icon')

### DIFF
--- a/app/imports/ui/components/directory/directory-profile.html
+++ b/app/imports/ui/components/directory/directory-profile.html
@@ -22,7 +22,8 @@
     <div class="extra content">
       <div class="ui equal width center aligned grid">
         <div class="column">
-          <a id="message-to-profile"><i class="big mail icon"></i>{{ profile.username }}</a>
+          <i class="big mail icon"></i><br>
+          <a id="message-to-profile">{{ profile.username }}</a>
         </div>
         {{#if profile.youtube }}
           <div class="column"><a href="https://youtube.com/{{ profile.youtube}}"><i


### PR DESCRIPTION
Solution: You cannot have the 'mail' icon and the {{profile.username}} in the same anchor tag (a tag)
-->Right now, it will work because the 'mail' icon is not clickable. But this can be improved....